### PR TITLE
add ipynb to source_suffix in l.43 (with formatting documents)

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -13,40 +13,40 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
+# sys.path.insert(0, os.path.abspath('.'))
 
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+# needs_sphinx = '1.0'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'nbsphinx',
-    'sphinx.ext.mathjax',
+    "nbsphinx",
+    "sphinx.ext.mathjax",
 ]
-exclude_patterns = ['_build', '**.ipynb_checkpoints']
+exclude_patterns = ["_build", "**.ipynb_checkpoints"]
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
-source_suffix = [".rst", ".md"]
-# source_suffix = [".rst", ".ipynb"]
+# source_suffix = [".rst", ".md"]
+source_suffix = [".rst", ".ipynb"]
 
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
 project = "python_textbook"
@@ -67,7 +67,7 @@ release = "1.1"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = 'ja'
+language = "ja"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -78,7 +78,7 @@ language = 'ja'
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
@@ -96,7 +96,7 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # A list of ignored prefixes for module index sorting.
 # modindex_common_prefix = []
@@ -112,7 +112,7 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'alabaster'
+html_theme = "alabaster"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -141,7 +141,7 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
@@ -206,78 +206,80 @@ html_static_path = ['_static']
 # html_search_scorer = 'scorer.js'
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'python_textbookdoc'
+htmlhelp_basename = "python_textbookdoc"
 
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-'papersize': 'a4paper',
-
-# The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
-
-# Additional stuff for the LaTeX preamble.
-'preamble':r"""%
+    # The paper size ('letterpaper' or 'a4paper').
+    "papersize": "a4paper",
+    # The font size ('10pt', '11pt' or '12pt').
+    #'pointsize': '10pt',
+    # Additional stuff for the LaTeX preamble.
+    "preamble": r"""%
 \let\VerbatimGray\Verbatim
 \renewcommand{\Verbatim}[1][1]{\VerbatimGray[#1,frame=single, rulecolor=\color{gray}]}
 %
 \let\OrigVerbatim\Verbatim
 \renewcommand{\OriginalVerbatim}[1][1]{\VerbatimGray[#1,frame=single, rulecolor=\color{gray}]}
 """
-#%
-#\usepackage{datetime}
-#\newdateformat{monthyeardate}{%
-#  \monthname[\THEMONTH], \THEYEAR}
-#%
-#\makeatletter
-#\renewcommand{\maketitle}{
-#  \ifsphinxpdfoutput
-#    \begingroup
-#      \def\\{, }
-#      \def\and{and }
-#      \pdfinfo{
-#        /Author (\@author)
-#        /Title (\@title)
-#      }
-#    \endgroup
-#  \fi
-#  \begin{center}
-#    \sphinxlogo%
-#    \vspace{15pt}
-#    {\Huge \@title} \par
-#    \vspace{15pt}
-#  \end{center}
-#  \begin{flushright}
-#    {\Large\@author \par}
-#    \py@authoraddress \par
-#  \end{flushright}
-#  \begin{flushright}
-#    {\Large \monthyeardate\today\par}
-#    \py@authoraddress \par
-#  \end{flushright}
-#  \@thanks
-#  \setcounter{footnote}{0}
-#  \let\thanks\relax\let\maketitle\relax
-#}
-#\makeatother
-#"""
-
-# Latex figure (float) alignment
-#'figure_align': 'htbp',
+    #%
+    # \usepackage{datetime}
+    # \newdateformat{monthyeardate}{%
+    #  \monthname[\THEMONTH], \THEYEAR}
+    #%
+    # \makeatletter
+    # \renewcommand{\maketitle}{
+    #  \ifsphinxpdfoutput
+    #    \begingroup
+    #      \def\\{, }
+    #      \def\and{and }
+    #      \pdfinfo{
+    #        /Author (\@author)
+    #        /Title (\@title)
+    #      }
+    #    \endgroup
+    #  \fi
+    #  \begin{center}
+    #    \sphinxlogo%
+    #    \vspace{15pt}
+    #    {\Huge \@title} \par
+    #    \vspace{15pt}
+    #  \end{center}
+    #  \begin{flushright}
+    #    {\Large\@author \par}
+    #    \py@authoraddress \par
+    #  \end{flushright}
+    #  \begin{flushright}
+    #    {\Large \monthyeardate\today\par}
+    #    \py@authoraddress \par
+    #  \end{flushright}
+    #  \@thanks
+    #  \setcounter{footnote}{0}
+    #  \let\thanks\relax\let\maketitle\relax
+    # }
+    # \makeatother
+    # """
+    # Latex figure (float) alignment
+    #'figure_align': 'htbp',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'python_textbook.tex', '情報基礎演習［工学部］ プログラミング',
-     '京都大学工学部 物理工学科編', 'manual'),
+    (
+        master_doc,
+        "python_textbook.tex",
+        "情報基礎演習［工学部］ プログラミング",
+        "京都大学工学部 物理工学科編",
+        "manual",
+    ),
 ]
 
 latex_docclass = {
-    'howto': 'jsarticle',
-    'manual': 'jsbook',
+    "howto": "jsarticle",
+    "manual": "jsbook",
 }
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
@@ -305,8 +307,7 @@ latex_docclass = {
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'python_textbook', 'python_textbook Documentation',
-     [author], 1)
+    (master_doc, "python_textbook", "python_textbook Documentation", [author], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -319,9 +320,15 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'python_textbook', 'python_textbook Documentation',
-     author, 'python_textbook', 'One line description of project.',
-     'Miscellaneous'),
+    (
+        master_doc,
+        "python_textbook",
+        "python_textbook Documentation",
+        author,
+        "python_textbook",
+        "One line description of project.",
+        "Miscellaneous",
+    ),
 ]
 
 # Documents to append as an appendix to all manuals.


### PR DESCRIPTION
This change would be required since mathematical expressions are not properly displayed in readthedocs web pages without ".ipynb" in source_suffix list, .